### PR TITLE
fix a bug in RP_realloc

### DIFF
--- a/src/rpmalloc.cpp
+++ b/src/rpmalloc.cpp
@@ -115,6 +115,7 @@ size_t RP_malloc_size(void* ptr){
 }
 
 void* RP_realloc(void* ptr, size_t new_size){
+	if(ptr == nullptr) return RP_malloc(new_size);
 	if(!_rgs->in_range(SB_IDX, ptr)) return nullptr;
 	size_t old_size = RP_malloc_size(ptr);
 	if(old_size == new_size) {


### PR DESCRIPTION
now RP_realloc behaves as RP_malloc if ptr is null

(cherry picked from commit 5deb1f122da2c584ed1ea5709af1a4f553352cae)